### PR TITLE
Fixed: Compilation not working with new g++ versions

### DIFF
--- a/src/PhysicalInterfaces/GnutlsData.h
+++ b/src/PhysicalInterfaces/GnutlsData.h
@@ -4,7 +4,7 @@
 
 #include <vector>
 #include <memory>
-#include <cstdint>
+#include <string>
 
 #include <gnutls/gnutls.h>
 


### PR DESCRIPTION
When compiling with newer g++ version (i. e. on Debian bullseye), we get the following error: 

```
PhysicalInterfaces/GnutlsData.cpp: In constructor 'GnutlsData::GnutlsData(const string&)':                                                                                                                                                                                                                                     
PhysicalInterfaces/GnutlsData.cpp:12:33: error: invalid use of incomplete type 'const string' {aka 'const class std::__cxx11::basic_string<char>'}                                                                                                                                                                             
   12 |     _data.insert(_data.begin(), data.begin(), data.end());                                                                                                                                                                                                                                                             
      |                                 ^~~~                                                                                                                                                                                                                                                                                   
In file included from /usr/include/c++/10/iosfwd:39,                                                                                                                                                                                                                                                                           
                 from /usr/include/c++/10/memory:74,                                                                                                                                                                                                                                                                           
                 from PhysicalInterfaces/GnutlsData.h:6,                                                                                                                                                                                                                                                                       
                 from PhysicalInterfaces/GnutlsData.cpp:1:                                                                                                                                                                                                                                                                     
/usr/include/c++/10/bits/stringfwd.h:74:11: note: declaration of 'std::string' {aka 'class std::__cxx11::basic_string<char>'}                                                                                                                                                                                                  
   74 |     class basic_string;                                                                                                                                                                                                                                                                                                
      |           ^~~~~~~~~~~~                                                                                                                                                                                                                                                                                                 
PhysicalInterfaces/GnutlsData.cpp:12:47: error: invalid use of incomplete type 'const string' {aka 'const class std::__cxx11::basic_string<char>'}                                                                                                                                                                             
   12 |     _data.insert(_data.begin(), data.begin(), data.end());                                                                                                                                                                                                                                                             
      |                                               ^~~~                                                                                                                                                                                                                                                                     
In file included from /usr/include/c++/10/iosfwd:39,
                 from /usr/include/c++/10/memory:74,
                 from PhysicalInterfaces/GnutlsData.h:6,
                 from PhysicalInterfaces/GnutlsData.cpp:1:
/usr/include/c++/10/bits/stringfwd.h:74:11: note: declaration of 'std::string' {aka 'class std::__cxx11::basic_string<char>'}
   74 |     class basic_string;
      |           ^~~~~~~~~~~~
make[3]: *** [Makefile:527: PhysicalInterfaces/GnutlsData.lo] Error 1
make[3]: *** Waiting for unfinished jobs....
```

These changes hopefully make compilation work again (untested).